### PR TITLE
feat(participants): enable participants counter

### DIFF
--- a/localization/active.de.toml
+++ b/localization/active.de.toml
@@ -28,10 +28,12 @@ EventNotFound = "Ereignis nicht gefunden."
 EventLocked = "Ereignis ist gesperrt 🔒. Nur der Ersteller kann das Ereignis aktualisieren oder Spiele hinzufügen."
 
 Join = "Beitreten {{.Name}}"
+JoinEvent = "Ereignis beitreten"
 UpdatedAt = "<i>Aktualisiert am {{.Time}}</i>\n"
 Update = "Aktualisieren"
 NotComing = "Nicht teilnehmen"
 AddGame = "Spiel hinzufügen"
+Players = "Spieler"
 
 Open = "Hier klicken, um die Einstellungen für Ereignis {{.Name}} zu öffnen und beizutreten."
 

--- a/localization/active.en.toml
+++ b/localization/active.en.toml
@@ -28,10 +28,12 @@ EventNotFound = "Event not found."
 EventLocked = "Event is locked 🔒. Only the creator can update the event or add games."
 
 Join = "Join {{.Name}}"
+JoinEvent = "Join event"
 UpdatedAt = "<i>Updated at {{.Time}}</i>"
 Update = "Update"
 NotComing = "Not coming"
 AddGame = "Add a game"
+Players = "players"
 
 Open = "Click here to open event {{.Name }} settings and join."
 

--- a/localization/active.it.toml
+++ b/localization/active.it.toml
@@ -27,11 +27,13 @@ GameNotFound = "Gioco non trovato. Stai cercando di aggiornare le informazioni d
 EventNotFound = "Evento non trovato."
 EventLocked = "L'evento è bloccato 🔒. Solo il creatore può aggiornare l'evento o aggiungere giochi."
 
-Join = "Partecipa a {{.Name}}"  
+Join = "Partecipa a {{.Name}}"
+JoinEvent = "Partecipa all'evento"  
 UpdatedAt = "<i>Aggiornato alle {{.Time}}</i>"  
 Update = "Aggiorna"
 NotComing = "Non partecipo"
 AddGame = "Aggiungi un gioco"
+Players = "partecipanti"
 
 Open = "Premi qui per aprire le impostazioni dell'evento {{.Name}} e partecipare."
 

--- a/src/telegram/telegram.go
+++ b/src/telegram/telegram.go
@@ -123,6 +123,14 @@ func (t Telegram) CreateGame(c telebot.Context) error {
 	}
 	log.Printf("Event created with id: %s", eventID)
 
+	if strings.Contains(eventName, "👥") {
+		if _, err = t.DB.InsertBoardGame(eventID, models.PLAYER_COUNTER, -1, nil, nil, nil, nil); err != nil {
+			log.Println("Failed to add game:", err)
+			failedT := t.Localizer(c).MustLocalize(&i18n.LocalizeConfig{DefaultMessage: &i18n.Message{ID: "FailedToAddGame"}})
+			return c.Reply(failedT)
+		}
+	}
+
 	var event *models.Event
 
 	if event, err = t.DB.SelectEventByEventID(eventID); err != nil {

--- a/src/web/api/controller.go
+++ b/src/web/api/controller.go
@@ -113,6 +113,12 @@ func (c *Controller) Event(ctx *gin.Context) {
 		},
 	})
 
+	for i, bg := range event.BoardGames {
+		if bg.Name == models.PLAYER_COUNTER {
+			event.BoardGames[i].Name = localizer.MustLocalizeMessage(&i18n.Message{ID: "JoinEvent"})
+		}
+	}
+
 	// serve an html file
 	ctx.HTML(http.StatusOK, "event", gin.H{
 		"Id":             event.ID,
@@ -160,6 +166,10 @@ func (c *Controller) Game(ctx *gin.Context) {
 			game = &g
 			break
 		}
+	}
+
+	if game.Name == models.PLAYER_COUNTER {
+		game.Name = localizer.MustLocalizeMessage(&i18n.Message{ID: "JoinEvent"})
 	}
 
 	ctx.HTML(http.StatusOK, "game_info", gin.H{
@@ -297,6 +307,9 @@ func (c *Controller) UpdateGame(ctx *gin.Context) {
 	}
 
 	localizer := c.Localizer(&event.ChatID)
+	if game.Name == models.PLAYER_COUNTER {
+		game.Name = localizer.MustLocalizeMessage(&i18n.Message{ID: "JoinEvent"})
+	}
 
 	ctx.HTML(http.StatusOK, "game_info", gin.H{
 		"Id":                      event.ID,

--- a/templates/event.html
+++ b/templates/event.html
@@ -113,9 +113,19 @@
             <div class="game-info">
                 <p>🎲  
                     {{ if .BggUrl }}
-                    - <a href="{{ .BggUrl }}">{{ .BggName }}</a></p>
+                    - <a href="{{ .BggUrl }}">{{ .BggName }}</a>
                     {{ end }}
-                <p><strong>[{{ .Name }}]</strong> ({{ len .Participants }}/{{ .MaxPlayers }} {{ $players }})</p>
+                </p>
+                <p>
+                    <strong>[{{ .Name }}]</strong> 
+                    (
+                        {{ if ne .MaxPlayers -1 }}
+                            {{ len .Participants }}/{{ .MaxPlayers }} {{ $players }}
+                        {{ else }}
+                            {{ len .Participants }} {{ $players }}
+                        {{ end }}
+                    )
+                </p>
                 <div class="participants">
                     {{ if .Participants }}
                         {{ range .Participants }}


### PR DESCRIPTION
With this pr we introduce the concept of participants counter.
Player can use the special string `_PLAYER_COUNTER_` as a game name to add a special game.
Player can also use the emoji 👥 to automatically create this counter at event creation.

Introduce https://github.com/DangerBlack/boardgame_night_bot/issues/6
